### PR TITLE
Allow override of repo_head_branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ jobs:
 
 ### Inputs
 
-| Parameter          | Description                                                                     |
-| ------------------ | ------------------------------------------------------------------------------- |
-| `junit-paths`      | **Required.** Comma-separated list of glob paths to junit files.                |
-| `org-slug`         | **Required.** Organization slug.                                                |
-| `token`            | **Optional.** Organization token. Defaults to `TRUNK_API_TOKEN` env var.        |
-| `repo-head-branch` | **Optional.** Branch of repository head. Defaults to `GITHUB_HEAD_REF` env var. |
-| `tags`             | **Optional.** Comma separated list of custom `tag=value` pairs.                 |
+| Parameter          | Description                                                              |
+| ------------------ | ------------------------------------------------------------------------ |
+| `junit-paths`      | **Required.** Comma-separated list of glob paths to junit files.         |
+| `org-slug`         | **Required.** Organization slug.                                         |
+| `token`            | **Optional.** Organization token. Defaults to `TRUNK_API_TOKEN` env var. |
+| `repo-head-branch` | **Optional.** Branch of repository head.                                 |
+| `tags`             | **Optional.** Comma separated list of custom `tag=value` pairs.          |
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ jobs:
 
 ### Inputs
 
-| Parameter     | Description                                                              |
-| ------------- | ------------------------------------------------------------------------ |
-| `junit-paths` | **Required.** Comma-separated list of glob paths to junit files.         |
-| `org-slug`    | **Required.** Organization slug.                                         |
-| `token`       | **Optional.** Organization token. Defaults to `TRUNK_API_TOKEN` env var. |
-| `tags`        | **Optional.** Comma separated list of custom `tag=value` pairs.          |
+| Parameter          | Description                                                                   |
+| ------------------ | ----------------------------------------------------------------------------- |
+| `junit-paths`      | **Required.** Comma-separated list of glob paths to junit files.              |
+| `org-slug`         | **Required.** Organization slug.                                              |
+| `token`            | **Optional.** Organization token. Defaults to `TRUNK_API_TOKEN` env var.      |
+| `repo-head-branch` | **Optional.** Branch of repository head. Defaults to GITHUB_HEAD_REF env var. |
+| `tags`             | **Optional.** Comma separated list of custom `tag=value` pairs.               |
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ jobs:
 
 ### Inputs
 
-| Parameter          | Description                                                                   |
-| ------------------ | ----------------------------------------------------------------------------- |
-| `junit-paths`      | **Required.** Comma-separated list of glob paths to junit files.              |
-| `org-slug`         | **Required.** Organization slug.                                              |
-| `token`            | **Optional.** Organization token. Defaults to `TRUNK_API_TOKEN` env var.      |
-| `repo-head-branch` | **Optional.** Branch of repository head. Defaults to GITHUB_HEAD_REF env var. |
-| `tags`             | **Optional.** Comma separated list of custom `tag=value` pairs.               |
+| Parameter          | Description                                                                     |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `junit-paths`      | **Required.** Comma-separated list of glob paths to junit files.                |
+| `org-slug`         | **Required.** Organization slug.                                                |
+| `token`            | **Optional.** Organization token. Defaults to `TRUNK_API_TOKEN` env var.        |
+| `repo-head-branch` | **Optional.** Branch of repository head. Defaults to `GITHUB_HEAD_REF` env var. |
+| `tags`             | **Optional.** Comma separated list of custom `tag=value` pairs.                 |
 
 ## Questions
 

--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,9 @@ inputs:
   token:
     description: Organization token. Defaults to TRUNK_API_TOKEN env var.
     required: false
+  repo-head-branch:
+    description: Value to override branch of repository head. Defaults to GITHUB_HEAD_REF env var.
+    required: false
   tags:
     description: Comma separated list of custom tag=value pairs.
     required: false
@@ -19,11 +22,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.head_ref }}
-
     - name: Upload test results
       run: ${GITHUB_ACTION_PATH}/script.sh
       shell: bash
@@ -32,4 +30,5 @@ runs:
         JUNIT_PATHS: ${{ inputs.junit-paths }}
         ORG_URL_SLUG: ${{ inputs.org-slug }}
         INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_HEAD_REF: ${{ inputs.repo-head-branch }}
         TAGS: ${{ inputs.tags }}

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ inputs:
     description: Organization token. Defaults to TRUNK_API_TOKEN env var.
     required: false
   repo-head-branch:
-    description: Value to override branch of repository head. Defaults to GITHUB_HEAD_REF env var.
+    description: Value to override branch of repository head.
     required: false
   tags:
     description: Comma separated list of custom tag=value pairs.
@@ -30,5 +30,5 @@ runs:
         JUNIT_PATHS: ${{ inputs.junit-paths }}
         ORG_URL_SLUG: ${{ inputs.org-slug }}
         INPUT_TOKEN: ${{ inputs.token }}
-        INPUT_HEAD_REF: ${{ inputs.repo-head-branch }}
+        REPO_HEAD_BRANCH: ${{ inputs.repo-head-branch }}
         TAGS: ${{ inputs.tags }}

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+
     - name: Upload test results
       run: ${GITHUB_ACTION_PATH}/script.sh
       shell: bash

--- a/script.sh
+++ b/script.sh
@@ -40,7 +40,7 @@ set +x
     --junit-paths "${JUNIT_PATHS}" \
     --org-url-slug "${ORG_URL_SLUG}" \
     --token "${TOKEN}" \
-    --tags "${TAGS}" \
-    --repo-head-branch "${HEAD_REF}"
+    --repo-head-branch "${HEAD_REF}" \
+    --tags "${TAGS}"
 
 rm -rf ./trunk-analytics-uploader

--- a/script.sh
+++ b/script.sh
@@ -25,7 +25,8 @@ if [[ (-z ${INPUT_TOKEN}) && (-z ${TRUNK_API_TOKEN}) ]]; then
     echo "Missing trunk api token"
     exit 2
 fi
-TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}} # Defaults to TRUNK_API_TOKEN env var.
+TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}}       # Defaults to TRUNK_API_TOKEN env var.
+HEAD_REF=${INPUT_HEAD_REF:-${GITHUB_HEAD_REF}} # Defaults to GITHUB_HEAD_REF env var.
 
 # CLI.
 set -x
@@ -39,6 +40,7 @@ set +x
     --junit-paths "${JUNIT_PATHS}" \
     --org-url-slug "${ORG_URL_SLUG}" \
     --token "${TOKEN}" \
-    --tags "${TAGS}"
+    --tags "${TAGS}" \
+    --repo-head-branch "${HEAD_REF}"
 
 rm -rf ./trunk-analytics-uploader

--- a/script.sh
+++ b/script.sh
@@ -25,8 +25,7 @@ if [[ (-z ${INPUT_TOKEN}) && (-z ${TRUNK_API_TOKEN}) ]]; then
     echo "Missing trunk api token"
     exit 2
 fi
-TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}}       # Defaults to TRUNK_API_TOKEN env var.
-HEAD_REF=${INPUT_HEAD_REF:-${GITHUB_HEAD_REF}} # Defaults to GITHUB_HEAD_REF env var.
+TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}} # Defaults to TRUNK_API_TOKEN env var.
 
 # CLI.
 set -x
@@ -40,7 +39,7 @@ set +x
     --junit-paths "${JUNIT_PATHS}" \
     --org-url-slug "${ORG_URL_SLUG}" \
     --token "${TOKEN}" \
-    --repo-head-branch "${HEAD_REF}" \
+    --repo-head-branch "${REPO_HEAD_BRANCH}" \
     --tags "${TAGS}"
 
 rm -rf ./trunk-analytics-uploader


### PR DESCRIPTION
- we should let users explicitly override the repo_head_branch
- defaults to GITHUB_HEAD_REF in the cli