### PR TITLE
Update analytics uploader versioning

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ inputs:
   tags:
     description: Comma separated list of custom tag=value pairs.
     required: false
-  version:
+  cli_version:
     description: The version of the uploader to use.
     required: false
     default: 0.4.0
@@ -40,4 +40,4 @@ runs:
         REPO_HEAD_BRANCH: ${{ inputs.repo-head-branch }}
         TAGS: ${{ inputs.tags }}
         RUN: ${{ inputs.run }}
-        VERSION: ${{ inputs.version }}
+        CLI_VERSION: ${{ inputs.cli_version }}

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,9 @@ inputs:
   repo-head-branch:
     description: Value to override branch of repository head.
     required: false
+  run:
+    description: The command to run before uploading test results.
+    required: false
   tags:
     description: Comma separated list of custom tag=value pairs.
     required: false
@@ -32,3 +35,4 @@ runs:
         INPUT_TOKEN: ${{ inputs.token }}
         REPO_HEAD_BRANCH: ${{ inputs.repo-head-branch }}
         TAGS: ${{ inputs.tags }}
+        RUN: ${{ inputs.run }}

--- a/action.yaml
+++ b/action.yaml
@@ -40,4 +40,4 @@ runs:
         REPO_HEAD_BRANCH: ${{ inputs.repo-head-branch }}
         TAGS: ${{ inputs.tags }}
         RUN: ${{ inputs.run }}
-        CLI_VERSION: ${{ inputs.cli_version }}
+        CLI_VERSION: ${{ inputs.cli-version }}

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,10 @@ inputs:
   tags:
     description: Comma separated list of custom tag=value pairs.
     required: false
+  version:
+    description: The version of the uploader to use.
+    required: false
+    default: 0.4.0
 
 runs:
   using: composite
@@ -36,3 +40,4 @@ runs:
         REPO_HEAD_BRANCH: ${{ inputs.repo-head-branch }}
         TAGS: ${{ inputs.tags }}
         RUN: ${{ inputs.run }}
+        VERSION: ${{ inputs.version }}

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ inputs:
   tags:
     description: Comma separated list of custom tag=value pairs.
     required: false
-  cli_version:
+  cli-version:
     description: The version of the uploader to use.
     required: false
     default: 0.4.0

--- a/script.sh
+++ b/script.sh
@@ -35,11 +35,21 @@ fi
 chmod +x ./trunk-analytics-uploader
 set +x
 
-./trunk-analytics-uploader upload \
-    --junit-paths "${JUNIT_PATHS}" \
-    --org-url-slug "${ORG_URL_SLUG}" \
-    --token "${TOKEN}" \
-    --repo-head-branch "${REPO_HEAD_BRANCH}" \
-    --tags "${TAGS}"
+if [[ -z ${RUN} ]]; then
+  ./trunk-analytics-uploader upload \
+      --junit-paths "${JUNIT_PATHS}" \
+      --org-url-slug "${ORG_URL_SLUG}" \
+      --token "${TOKEN}" \
+      --repo-head-branch "${REPO_HEAD_BRANCH}" \
+      --tags "${TAGS}"
+else
+  ./trunk-analytics-uploader test \
+      --junit-paths "${JUNIT_PATHS}" \
+      --org-url-slug "${ORG_URL_SLUG}" \
+      --token "${TOKEN}" \
+      --repo-head-branch "${REPO_HEAD_BRANCH}" \
+      --tags "${TAGS}"
+      -- "${RUN}"
+fi
 
 rm -rf ./trunk-analytics-uploader

--- a/script.sh
+++ b/script.sh
@@ -41,7 +41,6 @@ if [[ ! (-f ./trunk-analytics-cli) ]]; then
     curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/download/${VERSION}/trunk-analytics-cli-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o ./trunk-analytics-cli.tar.gz
 fi
 tar -xvzf trunk-analytics-cli.tar.gz
-ls
 chmod +x ./trunk-analytics-cli
 set +x
 

--- a/script.sh
+++ b/script.sh
@@ -21,7 +21,7 @@ if [[ -z ${ORG_URL_SLUG} ]]; then
     exit 2
 fi
 
-if [[ -z ${VERSION} ]]; then
+if [[ -z ${CLI_VERSION} ]]; then
     echo "Missing analytics cli version"
     exit 2
 fi
@@ -38,7 +38,7 @@ TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}} # Defaults to TRUNK_API_TOKEN env var.
 # CLI.
 set -x
 if [[ ! (-f ./trunk-analytics-cli) ]]; then
-    curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/download/${VERSION}/trunk-analytics-cli-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o ./trunk-analytics-cli.tar.gz
+    curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/download/${CLI_VERSION}/trunk-analytics-cli-${CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o ./trunk-analytics-cli.tar.gz
 fi
 tar -xvzf trunk-analytics-cli.tar.gz
 chmod +x ./trunk-analytics-cli

--- a/script.sh
+++ b/script.sh
@@ -21,35 +21,45 @@ if [[ -z ${ORG_URL_SLUG} ]]; then
     exit 2
 fi
 
+if [[ -z ${VERSION} ]]; then
+    echo "Missing analytics cli version"
+    exit 2
+fi
+
 if [[ (-z ${INPUT_TOKEN}) && (-z ${TRUNK_API_TOKEN-}) ]]; then
     echo "Missing trunk api token"
     exit 2
 fi
+RUN="${RUN-}"
+REPO_HEAD_BRANCH="${REPO_HEAD_BRANCH-}"
+TAGS="${TAGS-}"
 TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}} # Defaults to TRUNK_API_TOKEN env var.
 
 # CLI.
 set -x
-if [[ ! (-f ./trunk-analytics-uploader) ]]; then
-    curl -fsSL --retry 3 "https://trunk.io/releases/analytics-cli/latest" -o ./trunk-analytics-uploader
+if [[ ! (-f ./trunk-analytics-cli) ]]; then
+    curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/download/${VERSION}/trunk-analytics-cli-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o ./trunk-analytics-cli.tar.gz
 fi
-chmod +x ./trunk-analytics-uploader
+tar -xvzf trunk-analytics-cli.tar.gz
+ls
+chmod +x ./trunk-analytics-cli
 set +x
 
 if [[ -z ${RUN} ]]; then
-  ./trunk-analytics-uploader upload \
-      --junit-paths "${JUNIT_PATHS}" \
-      --org-url-slug "${ORG_URL_SLUG}" \
-      --token "${TOKEN}" \
-      --repo-head-branch "${REPO_HEAD_BRANCH}" \
-      --tags "${TAGS}"
+    ./trunk-analytics-cli upload \
+        --junit-paths "${JUNIT_PATHS}" \
+        --org-url-slug "${ORG_URL_SLUG}" \
+        --token "${TOKEN}" \
+        --repo-head-branch "${REPO_HEAD_BRANCH}" \
+        --tags "${TAGS}"
 else
-  ./trunk-analytics-uploader test \
-      --junit-paths "${JUNIT_PATHS}" \
-      --org-url-slug "${ORG_URL_SLUG}" \
-      --token "${TOKEN}" \
-      --repo-head-branch "${REPO_HEAD_BRANCH}" \
-      --tags "${TAGS}"
-      -- "${RUN}"
+    ./trunk-analytics-cli test \
+        --junit-paths "${JUNIT_PATHS}" \
+        --org-url-slug "${ORG_URL_SLUG}" \
+        --token "${TOKEN}" \
+        --repo-head-branch "${REPO_HEAD_BRANCH}" \
+        --tags "${TAGS}" \
+        -- "${RUN}"
 fi
 
-rm -rf ./trunk-analytics-uploader
+rm -rf ./trunk-analytics-cli ./trunk-analytics-cli.tar.gz


### PR DESCRIPTION
We added `test` as a subcommand in https://github.com/trunk-io/analytics-cli/pull/31. We need to update the uploader to handle pulling the cli from the GitHub release and also update it to handle the `test` subcommand.