### PR TITLE
Better resolve how `run` command is specified

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - name: Upload test results
-      run: ${GITHUB_ACTION_PATH}/script.sh
+      run: ${GITHUB_ACTION_PATH}/script.sh -- ${{ inputs.run }}
       shell: bash
       continue-on-error: true
       env:
@@ -39,5 +39,4 @@ runs:
         INPUT_TOKEN: ${{ inputs.token }}
         REPO_HEAD_BRANCH: ${{ inputs.repo-head-branch }}
         TAGS: ${{ inputs.tags }}
-        RUN: ${{ inputs.run }}
         CLI_VERSION: ${{ inputs.cli-version }}

--- a/script.sh
+++ b/script.sh
@@ -37,7 +37,6 @@ if [[ (-z ${INPUT_TOKEN}) && (-z ${TRUNK_API_TOKEN-}) ]]; then
     echo "Missing trunk api token"
     exit 2
 fi
-RUN="${RUN-}"
 REPO_HEAD_BRANCH="${REPO_HEAD_BRANCH-}"
 TAGS="${TAGS-}"
 TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}} # Defaults to TRUNK_API_TOKEN env var.
@@ -51,7 +50,7 @@ tar -xvzf trunk-analytics-cli.tar.gz
 chmod +x ./trunk-analytics-cli
 set +x
 
-if [[ -z ${RUN} ]]; then
+if [[ $# -eq 0 ]]; then
     ./trunk-analytics-cli upload \
         --junit-paths "${JUNIT_PATHS}" \
         --org-url-slug "${ORG_URL_SLUG}" \
@@ -64,6 +63,5 @@ else
         --org-url-slug "${ORG_URL_SLUG}" \
         --token "${TOKEN}" \
         --repo-head-branch "${REPO_HEAD_BRANCH}" \
-        --tags "${TAGS}" \
-        -- "${RUN}"
+        --tags "${TAGS}" "$@"
 fi


### PR DESCRIPTION
The analytics CLI is improperly handling parsing the command when specified as is. As a short term fix, we should update the script to take in the list of args and pass it directly through to the analytics cli. Separately we'll fix the parsing issue on the CLI.