### PR TITLE
rename linux bin, add support for linux arm64

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ inputs:
   cli-version:
     description: The version of the uploader to use.
     required: false
-    default: 0.5.17
+    default: 0.5.19
   team:
     description: Value to tag team owner of upload.
     required: false

--- a/script.sh
+++ b/script.sh
@@ -20,12 +20,16 @@ if [[ ${kernel} == "Darwin" ]]; then
         bin="x86_64-apple-darwin"
     fi
 elif [[ ${kernel} == "Linux" ]]; then
-    if [[ ${machine} == "x86_64" ]]; then
-        bin="x86_64-unknown-linux-musl"
+    if [[ ${machine} == "arm64" ]]; then
+        bin="aarch64-unknown-linux"
     elif [[ ${machine} == "x86_64" ]]; then
-        echo "Linux arm is currently supported"
-        exit 1
+        bin="x86_64-unknown-linux"
     fi
+fi
+
+if [[ -z ${bin} ]]; then
+    echo "Unsupported OS (${kernel}, ${machine})"
+    exit 1
 fi
 
 # Required inputs.
@@ -48,6 +52,7 @@ if [[ (-z ${INPUT_TOKEN}) && (-z ${TRUNK_API_TOKEN-}) ]]; then
     echo "Missing trunk api token"
     exit 2
 fi
+
 REPO_HEAD_BRANCH="${REPO_HEAD_BRANCH-}"
 REPO_ROOT="${REPO_ROOT-}"
 TAGS="${TAGS-}"


### PR DESCRIPTION
Update to use simplified binary naming introduced in
https://github.com/trunk-io/analytics-cli/pull/79

see release `0.5.19`:
https://github.com/trunk-io/analytics-cli/releases/tag/0.5.19