### PR TITLE
Set continue-on-error true only when not quarantining

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,7 +41,7 @@ runs:
     - name: Upload test results
       run: ${GITHUB_ACTION_PATH}/script.sh ${{ inputs.run }}
       shell: bash
-      continue-on-error: ${{ inputs.run == '' }}
+      continue-on-error: ${{ inputs.run == '' && inputs.quarantine == '' }}
       env:
         JUNIT_PATHS: ${{ inputs.junit-paths }}
         ORG_URL_SLUG: ${{ inputs.org-slug }}


### PR DESCRIPTION
Fixes a bug that was causing the upload step to succeed even when we were using it for quarantining. 