### PR TITLE
Default to allow missing junit xml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,10 @@ inputs:
   quarantine:
     description: Whether or not to allow quarantining of failing tests.
     required: false
+  allow-missing-junit-files:
+    description: Whether or not to allow missing junit files in the upload invocation
+    required: false
+    default: true
 
 runs:
   using: composite
@@ -56,3 +60,4 @@ runs:
         TEAM: ${{ inputs.team }}
         QUARANTINE: ${{ inputs.quarantine }}
         XCRESULT_PATH: ${{ inputs.xcresult-path }}
+        ALLOW_MISSING_JUNIT_FILES: ${{ inputs.allow-missing-junit-files }}

--- a/script.sh
+++ b/script.sh
@@ -59,6 +59,10 @@ TAGS="${TAGS-}"
 TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}} # Defaults to TRUNK_API_TOKEN env var.
 TEAM="${TEAM-}"
 XCRESULT_PATH="${XCRESULT_PATH-}"
+# clear ALLOW_MISSING_JUNIT_FILES if it is not equal to true
+if [[ ${ALLOW_MISSING_JUNIT_FILES} != "true" && ${ALLOW_MISSING_JUNIT_FILES} != "True" ]]; then
+    ALLOW_MISSING_JUNIT_FILES=""
+fi
 
 # CLI.
 set -x
@@ -79,7 +83,7 @@ if [[ $# -eq 0 ]]; then
         --repo-root "${REPO_ROOT}" \
         --team "${TEAM}" \
         --tags "${TAGS}" \
-        --allow-missing-junit-files "${ALLOW_MISSING_JUNIT_FILES}" \
+        ${ALLOW_MISSING_JUNIT_FILES:+--allow-missing-junit-files} \
         ${QUARANTINE:+--use-quarantining}
 else
     ./trunk-analytics-cli test \
@@ -91,6 +95,6 @@ else
         --repo-root "${REPO_ROOT}" \
         --team "${TEAM}" \
         --tags "${TAGS}" \
-        --allow-missing-junit-files "${ALLOW_MISSING_JUNIT_FILES}" \
+        ${ALLOW_MISSING_JUNIT_FILES:+--allow-missing-junit-files} \
         ${QUARANTINE:+--use-quarantining} "$@"
 fi

--- a/script.sh
+++ b/script.sh
@@ -79,6 +79,7 @@ if [[ $# -eq 0 ]]; then
         --repo-root "${REPO_ROOT}" \
         --team "${TEAM}" \
         --tags "${TAGS}" \
+        --allow-missing-junit-files "${ALLOW_MISSING_JUNIT_FILES}" \
         ${QUARANTINE:+--use-quarantining}
 else
     ./trunk-analytics-cli test \
@@ -90,5 +91,6 @@ else
         --repo-root "${REPO_ROOT}" \
         --team "${TEAM}" \
         --tags "${TAGS}" \
+        --allow-missing-junit-files "${ALLOW_MISSING_JUNIT_FILES}" \
         ${QUARANTINE:+--use-quarantining} "$@"
 fi


### PR DESCRIPTION
The default behavior of `continue-on-error` changed in https://github.com/trunk-io/analytics-uploader/pull/48. Missing junit files have always erred, but we were hiding that until the change went through. This cause quarantined test runs without junit files to suddenly start failing.