### PR TITLE
Update default cli version to 0.5.32

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ inputs:
   cli-version:
     description: The version of the uploader to use.
     required: false
-    default: 0.5.30
+    default: 0.5.32
   team:
     description: Value to tag team owner of upload.
     required: false


### PR DESCRIPTION
Version taken from most current release of analytics cli - https://github.com/trunk-io/analytics-cli/releases/tag/0.5.32