### PR TITLE
Only pass --repo-head-branch if env var is set & non-empty

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,6 @@ inputs:
   repo-head-branch:
     description: Value to override branch of repository head.
     required: false
-    default: $GITHUB_REF
   run:
     description: The command to run before uploading test results.
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,7 @@ inputs:
   repo-head-branch:
     description: Value to override branch of repository head.
     required: false
+    default: $GITHUB_REF
   run:
     description: The command to run before uploading test results.
     required: false

--- a/script.sh
+++ b/script.sh
@@ -79,7 +79,7 @@ if [[ $# -eq 0 ]]; then
         ${XCRESULT_PATH:+--xcresult-path "${XCRESULT_PATH}"} \
         --org-url-slug "${ORG_URL_SLUG}" \
         --token "${TOKEN}" \
-        --repo-head-branch "${REPO_HEAD_BRANCH}" \
+        ${REPO_HEAD_BRANCH:+--repo-head-branch "${REPO_HEAD_BRANCH}"} \
         --repo-root "${REPO_ROOT}" \
         --team "${TEAM}" \
         --tags "${TAGS}" \
@@ -91,7 +91,7 @@ else
         ${XCRESULT_PATH:+--xcresult-path "${XCRESULT_PATH}"} \
         --org-url-slug "${ORG_URL_SLUG}" \
         --token "${TOKEN}" \
-        --repo-head-branch "${REPO_HEAD_BRANCH}" \
+        ${REPO_HEAD_BRANCH:+--repo-head-branch "${REPO_HEAD_BRANCH}"} \
         --repo-root "${REPO_ROOT}" \
         --team "${TEAM}" \
         --tags "${TAGS}" \


### PR DESCRIPTION
The current behavior of the uploader is to always pass `--repo-head-branch` to the CLI, even if `$REPO_HEAD_BRANCH` (which comes from an optional input to this action) is empty. This causes the CLI to interpret the passed _empty string_ as the head branch [here](https://github.com/trunk-io/analytics-cli/blob/6f3799fc98da6dfc1017dbdc4e6f112cd397be04/context/src/repo/mod.rs#L91-L98), bypassing its logic to attempt to derive the branch from git state.

Example meta.json with **current behavior** when `repo-head-branch` is **not** passed to the uploader:

```
$ cat meta.json | jq | grep repo_head_branch
    "repo_head_branch": "",
```

Example meta.json **with changes in this PR** when `repo-head-branch` is **not** passed to the uploader:

```
$ cat meta.json | jq | grep repo_head_branch
    "repo_head_branch": "refs/remotes/pull/6/merge",
```

Tested in flake factory: https://github.com/trunk-io/flake-factory/actions/runs/11781727584/job/32815164337?pr=10303#step:5:574