### PR TITLE
(Fix): Only untar if we curl

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -68,8 +68,8 @@ fi
 set -x
 if [[ ! (-f ./trunk-analytics-cli) ]]; then
     curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/download/${CLI_VERSION}/trunk-analytics-cli-${bin}.tar.gz" -o ./trunk-analytics-cli.tar.gz
+    tar -xvzf trunk-analytics-cli.tar.gz
 fi
-tar -xvzf trunk-analytics-cli.tar.gz
 chmod +x ./trunk-analytics-cli
 set +x
 


### PR DESCRIPTION
This removes the (accidental) requirement of `trunk-analytics-cli.tar.gz` being in the repo if `trunk-analytics-cli` is also present

See [failure](https://github.com/agraebe/flake-factory/actions/runs/12203888697/job/34047827116#step:7:32)