### PR TITLE
(Feat): Add input for `--bazel-bep-path`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -34,11 +34,14 @@ inputs:
   xcresult-path:
     description: Path to the xcresult directory.
     required: false
+  bazel-bep-path:
+    description: Path to the bazel BEP file to parse in place of junits.
+    required: false
   quarantine:
     description: Whether or not to allow quarantining of failing tests.
     required: false
   allow-missing-junit-files:
-    description: Whether or not to allow missing junit files in the upload invocation
+    description: Whether or not to allow missing junit files in the upload invocation.
     required: false
     default: true
 
@@ -61,3 +64,4 @@ runs:
         QUARANTINE: ${{ inputs.quarantine }}
         XCRESULT_PATH: ${{ inputs.xcresult-path }}
         ALLOW_MISSING_JUNIT_FILES: ${{ inputs.allow-missing-junit-files }}
+        BAZEL_BEP_PATH: ${{ inputs.bazel-bep-path }}

--- a/script.sh
+++ b/script.sh
@@ -33,7 +33,7 @@ if [[ -z ${bin} ]]; then
 fi
 
 # Required inputs.
-if [[ (-z ${JUNIT_PATHS}) && (-z ${XCRESULT_PATH}) ]]; then
+if [[ (-z ${JUNIT_PATHS}) && (-z ${XCRESULT_PATH}) && (-z ${BAZEL_BEP_PATH}) ]]; then
     echo "Missing input files"
     exit 2
 fi
@@ -58,7 +58,9 @@ REPO_ROOT="${REPO_ROOT-}"
 TAGS="${TAGS-}"
 TOKEN=${INPUT_TOKEN:-${TRUNK_API_TOKEN}} # Defaults to TRUNK_API_TOKEN env var.
 TEAM="${TEAM-}"
+JUNIT_PATHS="${JUNIT_PATHS-}"
 XCRESULT_PATH="${XCRESULT_PATH-}"
+BAZEL_BEP_PATH="${BAZEL_BEP_PATH-}"
 # clear ALLOW_MISSING_JUNIT_FILES if it is not equal to true
 if [[ ${ALLOW_MISSING_JUNIT_FILES} != "true" && ${ALLOW_MISSING_JUNIT_FILES} != "True" ]]; then
     ALLOW_MISSING_JUNIT_FILES=""
@@ -77,6 +79,7 @@ if [[ $# -eq 0 ]]; then
     ./trunk-analytics-cli upload \
         ${JUNIT_PATHS:+--junit-paths "${JUNIT_PATHS}"} \
         ${XCRESULT_PATH:+--xcresult-path "${XCRESULT_PATH}"} \
+        ${BAZEL_BEP_PATH:+--bazel-bep-path "${BAZEL_BEP_PATH}"} \
         --org-url-slug "${ORG_URL_SLUG}" \
         --token "${TOKEN}" \
         ${REPO_HEAD_BRANCH:+--repo-head-branch "${REPO_HEAD_BRANCH}"} \
@@ -89,6 +92,7 @@ else
     ./trunk-analytics-cli test \
         ${JUNIT_PATHS:+--junit-paths "${JUNIT_PATHS}"} \
         ${XCRESULT_PATH:+--xcresult-path "${XCRESULT_PATH}"} \
+        ${BAZEL_BEP_PATH:+--bazel-bep-path "${BAZEL_BEP_PATH}"} \
         --org-url-slug "${ORG_URL_SLUG}" \
         --token "${TOKEN}" \
         ${REPO_HEAD_BRANCH:+--repo-head-branch "${REPO_HEAD_BRANCH}"} \


### PR DESCRIPTION
Adds input for `--bazel-bep-path`. This is only compatible with `analytics-cli` versions `0.6.6` and above

Not sure if this should be marked more as a beta feature somewhere (or only pass as an env var).