### PR TITLE
(Fix): Use tr for better compatibility

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -10,9 +10,10 @@ cleanup() {
 }
 
 parse_bool() {
-    if [[ ${1,,} == "true" ]]; then
+    lower_input=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+    if [[ ${lower_input} == "true" ]]; then
         echo "${2}=true"
-    elif [[ ${1,,} == "false" ]]; then
+    elif [[ ${lower_input} == "false" ]]; then
         echo "${2}=false"
     else
         echo ""


### PR DESCRIPTION
Follow-up to #69. Got the error `line 13: ${1,,}: bad substitution` in [job](https://github.com/trunk-io/plugins/actions/runs/12466084267/job/34792988610?pr=938). Bash <4.0.0 doesn't support the lowercase expansion. Switched to using `tr` for this instead.

Verified success in [job](https://github.com/trunk-io/plugins/actions/runs/12550456130/job/34993247855?pr=938)