### PR TITLE
Always point to latest CLI

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ inputs:
   cli-version:
     description: The version of the uploader to use.
     required: false
-    default: 0.6.19
+    default: latest
   team:
     description: Value to tag team owner of upload.
     required: false

--- a/script.sh
+++ b/script.sh
@@ -79,10 +79,11 @@ QUARANTINE_ARG=$(parse_bool "${QUARANTINE}" "--use-quarantining")
 set -x
 if [[ ${CLI_VERSION} == "latest" ]]; then
     curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/latest/download/trunk-analytics-cli-${bin}.tar.gz" -o ./trunk-analytics-cli.tar.gz
+    tar -xvzf trunk-analytics-cli.tar.gz
 elif [[ ! (-f ./trunk-analytics-cli) ]]; then
     curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/download/${CLI_VERSION}/trunk-analytics-cli-${bin}.tar.gz" -o ./trunk-analytics-cli.tar.gz
+    tar -xvzf trunk-analytics-cli.tar.gz
 fi
-tar -xvzf trunk-analytics-cli.tar.gz
 chmod +x ./trunk-analytics-cli
 set +x
 

--- a/script.sh
+++ b/script.sh
@@ -77,10 +77,12 @@ QUARANTINE_ARG=$(parse_bool "${QUARANTINE}" "--use-quarantining")
 
 # CLI.
 set -x
-if [[ ! (-f ./trunk-analytics-cli) ]]; then
+if [[ ${CLI_VERSION} == "latest" ]]; then
+    curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/latest/download/trunk-analytics-cli-${bin}.tar.gz" -o ./trunk-analytics-cli.tar.gz
+elif [[ ! (-f ./trunk-analytics-cli) ]]; then
     curl -fsSL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/download/${CLI_VERSION}/trunk-analytics-cli-${bin}.tar.gz" -o ./trunk-analytics-cli.tar.gz
-    tar -xvzf trunk-analytics-cli.tar.gz
 fi
+tar -xvzf trunk-analytics-cli.tar.gz
 chmod +x ./trunk-analytics-cli
 set +x
 

--- a/tests/arguments.test.ts
+++ b/tests/arguments.test.ts
@@ -58,7 +58,8 @@ test("Forwards inputs", async () => {
   expect({ stdout, stderr, exit_code }).toMatchObject({
     stdout:
       "upload --junit-paths junit.xml --org-url-slug org --token token --repo-root --team --tags",
-    stderr: `+ [[ -f ./trunk-analytics-cli ]]
+    stderr: `+ [[ 0.0.0 == \\l\\a\\t\\e\\s\\t ]]
++ [[ -f ./trunk-analytics-cli ]]
 + chmod +x ./trunk-analytics-cli
 + set +x
 `,


### PR DESCRIPTION
We allow overrides so users can force the cli to a specific version. Otherwise they should use the latest.