### PR TITLE
Remove continue-on-error override

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -54,7 +54,6 @@ runs:
     - name: Upload test results
       run: ${GITHUB_ACTION_PATH}/script.sh ${{ inputs.run }}
       shell: bash
-      continue-on-error: ${{ inputs.run == '' && (inputs.quarantine == '' || inputs.quarantine == 'false') }}
       env:
         JUNIT_PATHS: ${{ inputs.junit-paths }}
         ORG_URL_SLUG: ${{ inputs.org-slug }}


### PR DESCRIPTION
We've had users that had trouble with quarantining because of this override. It was originally put in place very early on in the beta as to not disrupt users' CI. We should not set it and instead have our users make the determination.