### PR TITLE
[TRUNK-14636] Use gh context with use_uncloned_repo

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,6 +50,10 @@ inputs:
   variant:
     description: User specified variant of a set of tests being uploaded.
     required: false
+  use-uncloned-repo:
+    description: Set to 'true' if your tests do not require cloning the repository under test,
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -73,3 +77,10 @@ runs:
         PR_TITLE: ${{ github.event.pull_request.title }}
         HIDE_BANNER: ${{ inputs.hide-banner }}
         VARIANT: ${{ inputs.variant }}
+        USE_UNCLONED_REPO: ${{ inputs.use-uncloned-repo }}
+        GH_REPO_URL: ${{ github.pull_request.head.repo.html_url }}
+        GH_REPO_HEAD_SHA: ${{ github.pull_request.head.sha }}
+        GH_REPO_HEAD_BRANCH: ${{ github.pull_request.head.ref }}
+        GH_REPO_HEAD_COMMIT_EPOCH: ${{ github.pull_request.updated_at }}
+        GH_REPO_HEAD_AUTHOR_NAME: ${{ github.pull_request.head.user.name }}
+        GH_REPO_HEAD_AUTHOR_EMAIL: ${{ github.pull_request.head.user.email }}

--- a/script.sh
+++ b/script.sh
@@ -75,6 +75,12 @@ ALLOW_MISSING_JUNIT_FILES_ARG=$(parse_bool "${ALLOW_MISSING_JUNIT_FILES}" "--all
 HIDE_BANNER=$(parse_bool "${HIDE_BANNER}" "--hide-banner")
 QUARANTINE_ARG=$(parse_bool "${QUARANTINE}" "--use-quarantining")
 VARIANT="${VARIANT-}"
+USE_UNCLONED_REPO_FLAG=""
+REPO_URL=""
+REPO_HEAD_SHA=""
+REPO_HEAD_COMMIT_EPOCH=""
+REPO_HEAD_AUTHOR_NAME=""
+REPO_HEAD_AUTHOR_EMAIL=""
 
 # CLI.
 set -x
@@ -87,6 +93,17 @@ elif [[ ! (-f ./trunk-analytics-cli) ]]; then
 fi
 chmod +x ./trunk-analytics-cli
 set +x
+
+# Uncloned repo rules
+if [[ ${USE_UNCLONED_REPO} == "true" ]]; then
+    USE_UNCLONED_REPO_FLAG="--use-uncloned-repo"
+    REPO_URL="--repo-url ${GH_REPO_URL}"
+    REPO_HEAD_SHA="--repo-head-sha ${GH_REPO_HEAD_BRANCH}"
+    REPO_HEAD_BRANCH="${GH_REPO_HEAD_BRANCH}"
+    REPO_HEAD_COMMIT_EPOCH="--repo-head-commit-epoch ${GH_REPO_HEAD_BRANCH}"
+    REPO_HEAD_AUTHOR_NAME="--repo-head-author-name ${GH_REPO_HEAD_BRANCH}"
+    REPO_HEAD_AUTHOR_EMAIL="--repo-head-author-email ${GH_REPO_HEAD_BRANCH}"
+fi
 
 # trunk-ignore-begin(shellcheck/SC2086)
 if [[ $# -eq 0 ]]; then
@@ -102,7 +119,14 @@ if [[ $# -eq 0 ]]; then
         ${ALLOW_MISSING_JUNIT_FILES_ARG} \
         ${HIDE_BANNER} \
         ${VARIANT:+--variant "${VARIANT}"} \
-        ${QUARANTINE_ARG}
+        ${QUARANTINE_ARG} \
+        "${USE_UNCLONED_REPO_FLAG}" \
+        ${REPO_URL} \
+        ${REPO_HEAD_SHA} \
+        ${REPO_HEAD_COMMIT_EPOCH} \
+        ${REPO_HEAD_AUTHOR_NAME} \
+        ${REPO_HEAD_AUTHOR_EMAIL}
+
 else
     ./trunk-analytics-cli test \
         ${JUNIT_PATHS:+--junit-paths "${JUNIT_PATHS}"} \
@@ -116,6 +140,12 @@ else
         ${ALLOW_MISSING_JUNIT_FILES_ARG} \
         ${HIDE_BANNER} \
         ${VARIANT:+--variant "${VARIANT}"} \
-        ${QUARANTINE_ARG} "$@"
+        ${QUARANTINE_ARG} \
+        "${USE_UNCLONED_REPO_FLAG}" \
+        ${REPO_URL} \
+        ${REPO_HEAD_SHA} \
+        ${REPO_HEAD_COMMIT_EPOCH} \
+        ${REPO_HEAD_AUTHOR_NAME} \
+        ${REPO_HEAD_AUTHOR_EMAIL} "$@"
 fi
 # trunk-ignore-end(shellcheck/SC2086)

--- a/tests/arguments.test.ts
+++ b/tests/arguments.test.ts
@@ -38,6 +38,7 @@ test("Forwards inputs", async () => {
     ALLOW_MISSING_JUNIT_FILES: "",
     BAZEL_BEP_PATH: "",
     HIDE_BANNER: "",
+    USE_UNCLONED_REPO: "false",
   };
 
   const scriptPath = path.resolve(repoRoot, "script.sh");


### PR DESCRIPTION
Adds a use_uncloned_repo flag that manually sets as much context as possible using gh context and the pull_request event.