### PR TITLE
Allow v2 as a major tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
         type: choice
         description: Target major version
         options:
+          - v2
           - v1
 concurrency: ${{ github.workflow }}
 


### PR DESCRIPTION
Since we're gearing up for v2 of the analytics-uploader, adding v2 as an option for releasing.