### PR TITLE
[TRUNK-15643] Download cli with direct request

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -51069,12 +51069,13 @@ const downloadRelease = async (owner, repo, version, bin, tmpdir) => {
     if (!asset) {
         throw new Error(`Asset ${assetName} not found in release ${version}`);
     }
-    const response = await octokit.request(`GET ${asset.url}`, {
+    const response = await fetch(asset.url, {
+        method: "GET",
         headers: {
             accept: "application/octet-stream",
         },
     });
-    external_fs_.writeFileSync(external_path_.join(tmpdir ?? ".", assetName), external_node_buffer_namespaceObject.Buffer.from(response.data));
+    external_fs_.writeFileSync(external_path_.join(tmpdir ?? ".", assetName), external_node_buffer_namespaceObject.Buffer.from(await response.arrayBuffer()));
     core.info(`Downloaded ${assetName} from release ${version}`);
     return external_path_.join(tmpdir ?? ".", assetName);
 };
@@ -51199,9 +51200,7 @@ const main = async (tmpdir) => {
                 ? `--test-process-exit-code=${parsePreviousStepOutcome(previousStepOutcome).toString()}`
                 : "",
             verbose === "true" ? "-v" : "",
-            showFailureMessages === "true"
-                ? "--show-failure-messages"
-                : "",
+            showFailureMessages === "true" ? "--show-failure-messages" : "",
             run ? `-- ${run}` : "",
         ].filter(Boolean);
         // Execute the command

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -90,7 +90,8 @@ const downloadRelease = async (
     throw new Error(`Asset ${assetName} not found in release ${version}`);
   }
 
-  const response = await octokit.request(`GET ${asset.url}`, {
+  const response = await fetch(asset.url, {
+    method: "GET",
     headers: {
       accept: "application/octet-stream",
     },
@@ -98,7 +99,7 @@ const downloadRelease = async (
 
   fs.writeFileSync(
     path.join(tmpdir ?? ".", assetName),
-    Buffer.from(response.data),
+    Buffer.from(await response.arrayBuffer()),
   );
   core.info(`Downloaded ${assetName} from release ${version}`);
   return path.join(tmpdir ?? ".", assetName);


### PR DESCRIPTION
Switches to node's fetch method for fetching the cli because octokit enforces rate limits, which causes problems for heavy users of the uploader.