### PR TITLE
[TRUNK-16601] Explicit cause for override error

### DIFF
--- a/__tests__/errors.test.ts
+++ b/__tests__/errors.test.ts
@@ -29,7 +29,7 @@ describe("handleCommandError", () => {
   });
 
   it("given Error with 'Command failed' and our manually set failure exit code", () => {
-    const expected = `Command failed with exit code ${FAILURE_PREVIOUS_STEP_CODE}`;
+    const expected = `Command failed with exit code ${FAILURE_PREVIOUS_STEP_CODE.toString()}`;
     const actual = handleCommandError(new Error(expected));
     expect(actual).toStrictEqual({ failureReason: undefined });
   });

--- a/__tests__/errors.test.ts
+++ b/__tests__/errors.test.ts
@@ -1,0 +1,59 @@
+import { jest } from "@jest/globals";
+
+import * as core from "../__fixtures__/core.js";
+jest.mock("@actions/core", () => core);
+
+import { FAILURE_PREVIOUS_STEP_CODE, handleCommandError } from "../src/lib.js";
+import { RequestError } from "octokit";
+
+describe("handleCommandError", () => {
+  it("given RequestError", () => {
+    const actual = handleCommandError(
+      new RequestError("path not found", 404, {
+        request: {
+          method: "GET",
+          url: "example.com/my-missing-path",
+          headers: {},
+        },
+      }),
+    );
+    const expected =
+      "Request to example.com/my-missing-path failed with status 404";
+    expect(actual).toStrictEqual({ failureReason: expected });
+  });
+
+  it("given Error with 'Command failed' and our 70 exit code", () => {
+    const expected = "Command failed with exit code 70";
+    const actual = handleCommandError(new Error(expected));
+    expect(actual).toStrictEqual({ failureReason: expected });
+  });
+
+  it("given Error with 'Command failed' and our manually set failure exit code", () => {
+    const expected = `Command failed with exit code ${FAILURE_PREVIOUS_STEP_CODE}`;
+    const actual = handleCommandError(new Error(expected));
+    expect(actual).toStrictEqual({ failureReason: undefined });
+  });
+
+  it("given Error with 'Command failed' and an unknown other code", () => {
+    const expected = "Command failed with exit code 214";
+    const actual = handleCommandError(new Error(expected));
+    expect(actual).toStrictEqual({ failureReason: undefined });
+  });
+
+  it("given other Error with an extremely long message", () => {
+    const expected =
+      "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 ";
+    const actual = handleCommandError(new Error(expected));
+    // This is a shortened form of the original message
+    expect(actual).toStrictEqual({
+      failureReason:
+        "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 ",
+    });
+  });
+
+  it("given a non-Error", () => {
+    const actual = handleCommandError({ key: "wow something went wrong" });
+    const expected = "An unknown error occurred";
+    expect(actual).toStrictEqual({ failureReason: expected });
+  });
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -51136,7 +51136,7 @@ const handleCommandError = (error) => {
     // check if exec sync error
     let failureReason = undefined;
     if (error instanceof Error && error.message.includes("Command failed")) {
-        if (error.message.includes(`exit code ${FAILURE_PREVIOUS_STEP_CODE}`)) {
+        if (error.message.includes(`exit code ${FAILURE_PREVIOUS_STEP_CODE.toString()}`)) {
             core.setFailed("The test results you are uploading contain test failures -- see above for details. This step will pass when the tests are fixed.");
         }
         else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -44813,7 +44813,7 @@ __nccwpck_require__.d(__webpack_exports__, {
   iW: () => (/* binding */ main)
 });
 
-// UNUSED EXPORTS: FAILURE_PREVIOUS_STEP_CODE, convertToTelemetry, fetchApiAddress, handleCommandError, parseBool, parsePreviousStepOutcome, previousStepFailed, semVerFromRef
+// UNUSED EXPORTS: convertToTelemetry, fetchApiAddress, handleCommandError, parseBool, parsePreviousStepOutcome, previousStepFailed, semVerFromRef
 
 // EXTERNAL MODULE: ./node_modules/.pnpm/@actions+core@1.11.1/node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(9999);
@@ -51017,7 +51017,6 @@ const TELEMETRY_RETRY = {
     maxTimeout: 10000,
     maxRetryTime: 10000,
 };
-const FAILURE_PREVIOUS_STEP_CODE = 1;
 // Cleanup to remove downloaded files
 const cleanup = (bin, dir = ".") => {
     try {
@@ -51149,7 +51148,7 @@ const handleCommandError = (error, previousStepOutcome) => {
     let failureReason = undefined;
     if (error instanceof Error && error.message.includes("Command failed")) {
         if (previousStepFailed(previousStepOutcome)) {
-            core.setFailed("The test results you are uploading contain test failures -- see above for details. This step will pass when the tests are fixed.");
+            core.setFailed("The test results you are uploading contain non quarantined test failures -- see above for details.");
         }
         else {
             if (error.message.includes("exit code 70")) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -51136,6 +51136,7 @@ const handleCommandError = (error) => {
     // check if exec sync error
     let failureReason = undefined;
     if (error instanceof Error && error.message.includes("Command failed")) {
+        core.error(`Got a message, ${error.message}`);
         if (error.message.includes(`exit code ${FAILURE_PREVIOUS_STEP_CODE.toString()}`)) {
             core.setFailed("The test results you are uploading contain test failures -- see above for details. This step will pass when the tests are fixed.");
         }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -173,6 +173,7 @@ export const handleCommandError = (
   // check if exec sync error
   let failureReason: string | undefined = undefined;
   if (error instanceof Error && error.message.includes("Command failed")) {
+    core.error(`Got a message, ${error.message}`);
     if (
       error.message.includes(
         `exit code ${FAILURE_PREVIOUS_STEP_CODE.toString()}`,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -19,7 +19,7 @@ const TELEMETRY_RETRY = {
   maxRetryTime: 10000,
 } satisfies OperationOptions;
 
-export const FAILURE_PREVIOUS_STEP_CODE: number = 1;
+export const FAILURE_PREVIOUS_STEP_CODE = 1;
 
 // Cleanup to remove downloaded files
 const cleanup = (bin: string, dir = "."): void => {
@@ -173,7 +173,11 @@ export const handleCommandError = (
   // check if exec sync error
   let failureReason: string | undefined = undefined;
   if (error instanceof Error && error.message.includes("Command failed")) {
-    if (error.message.includes(`exit code ${FAILURE_PREVIOUS_STEP_CODE}`)) {
+    if (
+      error.message.includes(
+        `exit code ${FAILURE_PREVIOUS_STEP_CODE.toString()}`,
+      )
+    ) {
       core.setFailed(
         "The test results you are uploading contain test failures -- see above for details. This step will pass when the tests are fixed.",
       );

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -19,8 +19,6 @@ const TELEMETRY_RETRY = {
   maxRetryTime: 10000,
 } satisfies OperationOptions;
 
-export const FAILURE_PREVIOUS_STEP_CODE = 1;
-
 // Cleanup to remove downloaded files
 const cleanup = (bin: string, dir = "."): void => {
   try {
@@ -189,7 +187,7 @@ export const handleCommandError = (
   if (error instanceof Error && error.message.includes("Command failed")) {
     if (previousStepFailed(previousStepOutcome)) {
       core.setFailed(
-        "The test results you are uploading contain test failures -- see above for details. This step will pass when the tests are fixed.",
+        "The test results you are uploading contain non quarantined test failures -- see above for details.",
       );
     } else {
       if (error.message.includes("exit code 70")) {


### PR DESCRIPTION
When the cli returns a 1, we should be ensuring that we tell them why
the 1 happened. Extracts out the error handling so that we can test it.
<img width="1113" height="1039" alt="Screenshot from 2025-10-07 11-54-06" src="https://github.com/user-attachments/assets/c106799a-c836-4f3e-90a6-5183242d7d5f" />
