### PR TITLE
feat: wire test collection IDs to upload steps

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           allow-missing-junit-files: false
           use-cache: true
-          test-collection-short-id: 7P54Ouzw
+          test-collection-id: 7P54Ouzw
 
       - name: Trunk Analytics Uploader (Staging)
         uses: ./
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           allow-missing-junit-files: false
           use-cache: true
-          test-collection-short-id: DqlUb3qM
+          test-collection-id: DqlUb3qM
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,6 +71,7 @@ jobs:
           token: ${{ secrets.TRUNK_PROD_ORG_API_TOKEN }}
           allow-missing-junit-files: false
           use-cache: true
+          test-collection-short-id: 7P54Ouzw
 
       - name: Trunk Analytics Uploader (Staging)
         uses: ./

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,6 +81,7 @@ jobs:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           allow-missing-junit-files: false
           use-cache: true
+          test-collection-short-id: DqlUb3qM
         env:
           TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 


### PR DESCRIPTION
## Summary

Wires Trunk Flaky Tests collection IDs to all test upload steps across repos, enabling per-collection flake tracking rather than repo-wide tracking. Adds both staging and prod collection IDs where applicable. Depends on the `--test-collection-id` CLI flag rename landing first.

## PRs

- [ ] trunk-io/analytics-cli#1119
- [ ] trunk-io/analytics-uploader#138
- [ ] trunk-io/trunk2#4188
- [ ] trunk-io/trunk#32649
- [ ] trunk-io/flake-farm#20280
- [ ] trunk-io/flake-farm-staging-fork-prs#283
- [ ] trunk-io/flake-farm-staging-fork-prs-generator#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)