### PR TITLE
docs: document use-bazel-target-for-codeowners input in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,20 @@ jobs:
 
 ### Optional Parameters
 
-| Parameter                   | Description                                                                                                                                  | Default  |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `repo-head-branch`          | Value to override branch of repository head.                                                                                                 |          |
-| `repo-root`                 | The root directory of the repository.                                                                                                        |          |
-| `run`                       | The command to run before uploading test results.                                                                                            |          |
-| `cli-version`               | The version of the uploader to use.                                                                                                          | `latest` |
+| Parameter                         | Description                                                                                                                                                                                      | Default  |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `repo-head-branch`                | Value to override branch of repository head.                                                                                                                                                     |          |
+| `repo-root`                       | The root directory of the repository.                                                                                                                                                            |          |
+| `run`                             | The command to run before uploading test results.                                                                                                                                                |          |
+| `cli-version`                     | The version of the uploader to use.                                                                                                                                                              | `latest` |
 | `use-bazel-target-for-codeowners` | Use the Bazel target label as a fallback path for CODEOWNERS association when no file attribute is present in the JUnit XML. Only relevant when uploading a Bazel BEP file via `bazel-bep-path`. | `false`  |
-| `allow-missing-junit-files` | Whether or not to allow missing junit files in the upload invocation.                                                                        | `true`   |
-| `variant`                   | User specified variant of a set of tests being uploaded.                                                                                     |          |
-| `verbose`                   | Enable verbose logging                                                                                                                       | `false`  |
-| `previous-step-outcome`     | The outcome of the previous step in the workflow. Set this equal to steps.[id].outcome where `[id]` is the id of the corresponding test run. |          |
-| `show-failure-messages`     | Show failure outputs in upload. This is experimental, do not rely on this.                                                                   | `false`  |
-| `dry-run`                   | Run without uploading the results to the server. They will instead be dumped to the directory that the action is run in.                     | `false`  |
-| `use-cache`                 | Enable caching of the trunk-analytics-cli binary to reduce subsequent downloads                                                              | `false`  |
+| `allow-missing-junit-files`       | Whether or not to allow missing junit files in the upload invocation.                                                                                                                            | `true`   |
+| `variant`                         | User specified variant of a set of tests being uploaded.                                                                                                                                         |          |
+| `verbose`                         | Enable verbose logging                                                                                                                                                                           | `false`  |
+| `previous-step-outcome`           | The outcome of the previous step in the workflow. Set this equal to steps.[id].outcome where `[id]` is the id of the corresponding test run.                                                     |          |
+| `show-failure-messages`           | Show failure outputs in upload. This is experimental, do not rely on this.                                                                                                                       | `false`  |
+| `dry-run`                         | Run without uploading the results to the server. They will instead be dumped to the directory that the action is run in.                                                                         | `false`  |
+| `use-cache`                       | Enable caching of the trunk-analytics-cli binary to reduce subsequent downloads                                                                                                                  | `false`  |
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ jobs:
 | `repo-root`                 | The root directory of the repository.                                                                                                        |          |
 | `run`                       | The command to run before uploading test results.                                                                                            |          |
 | `cli-version`               | The version of the uploader to use.                                                                                                          | `latest` |
+| `use-bazel-target-for-codeowners` | Use the Bazel target label as a fallback path for CODEOWNERS association when no file attribute is present in the JUnit XML. Only relevant when uploading a Bazel BEP file via `bazel-bep-path`. | `false`  |
 | `allow-missing-junit-files` | Whether or not to allow missing junit files in the upload invocation.                                                                        | `true`   |
 | `variant`                   | User specified variant of a set of tests being uploaded.                                                                                     |          |
 | `verbose`                   | Enable verbose logging                                                                                                                       | `false`  |


### PR DESCRIPTION
Adds the use-bazel-target-for-codeowners action input to the Optional Parameters table. This flag uses the Bazel target label as a fallback path for CODEOWNERS association when no file attribute is present in the JUnit XML, and is relevant when uploading a Bazel BEP file via bazel-bep-path.

https://claude.ai/code/session_018gqWjryt9ymejpRWmzNwvR